### PR TITLE
Add gem csv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,4 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "webrick", "~> 1.8"
+gem "csv"


### PR DESCRIPTION
必要になったので追加。

>  warning: csv was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.